### PR TITLE
don't use php end tags

### DIFF
--- a/convexHull.php
+++ b/convexHull.php
@@ -73,5 +73,3 @@
 			return null;
 		}
 	}
-
-?>


### PR DESCRIPTION
(except when absolutely necessary)

end tags are very bug-prone, if you accidentally have a newline or a space after the end tag, you will accidentally start outputting, header() calls will no longer work, someone has to debug why there's a bogus space in the beginning of the output, etc,

rule of thumb: don't use end tags.

(also if you're into the whole PSR-coding-standards thing, PSR2 states "The closing ?> tag MUST be omitted from files containing only PHP.", ref https://www.php-fig.org/psr/psr-2/ )